### PR TITLE
feat: declare and guard Secure Custom Fields (SCF) compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Toggling that option will hide or show the layout on the fronted.
 
 ## Dependencies
 * [WordPress](https://wordpress.org/) >= 4.7
-* [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) >= 5.7
+* [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) >= 5.7, **or** [Secure Custom Fields (SCF)](https://wordpress.org/plugins/secure-custom-fields/)
+
+## Secure Custom Fields (SCF) compatibility
+
+ACF Hide Layout works with both Advanced Custom Fields and [Secure Custom Fields (SCF)](https://wordpress.org/plugins/secure-custom-fields/), the WordPress.org-maintained fork of ACF. SCF keeps ACF's PHP and JS API (the `acf_*` functions, the `acf/*` filters and the `ACF_VERSION` constant), so no extra setup is needed.
+
+Because SCF ships Flexible Content for free, you can use this plugin without ACF Pro.
 
 ## Install
 1. Clone this repo to `/wp-content/plugins`.

--- a/acf-hide-layout.php
+++ b/acf-hide-layout.php
@@ -2,8 +2,8 @@
 /*
  * Plugin Name: ACF Hide Layout
  * Plugin URI: https://flyntwp.com/acf-hide-layout/
- * Description: Easily hide the layout of the flexible content on the frontend but still keep it in the backend.
- * Tags: acf, advanced custom fields, flexible content, hide layout
+ * Description: Easily hide the layout of the flexible content on the frontend but still keep it in the backend. Works with Advanced Custom Fields and Secure Custom Fields (SCF).
+ * Tags: acf, advanced custom fields, secure custom fields, scf, flexible content, hide layout
  * Version: 1.3.0
  * Author: Bleech
  * Author URI: https://bleech.de/
@@ -223,6 +223,7 @@ class ACF_Hide_Layout {
 		add_action( 'init', [ $this, 'init' ], 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_action( 'admin_footer', [ $this, 'admin_footer'] );
+		add_action( 'admin_notices', [ $this, 'maybe_show_dependency_notice' ] );
 		add_action( 'admin_notices', [ $this, 'maybe_show_admin_notice' ] );
 		add_action( 'wp_ajax_acf_hide_layout_dismiss_notice', [ $this, 'ajax_dismiss_notice' ] );
 		add_action( 'wp_ajax_acf_hide_layout_migrate_hidden_layouts', [ $this, 'ajax_migrate_hidden_layouts' ] );
@@ -486,6 +487,47 @@ class ACF_Hide_Layout {
 	public function supports_disabled_layouts() {
 		$version = defined( 'ACF_VERSION' ) ? constant( 'ACF_VERSION' ) : '0';
 		return version_compare( $version, '6.5', '>=' );
+	}
+
+	/**
+	 * Check if a compatible field framework (ACF or SCF) is active.
+	 *
+	 * Secure Custom Fields (SCF) is a drop-in fork of ACF that keeps the
+	 * `acf_*` API, the `acf/*` filters and the `ACF_VERSION` constant, so this
+	 * plugin works with either one.
+	 *
+	 * @since  1.4
+	 * @access public
+	 *
+	 * @return boolean
+	 */
+	public function dependency_active() {
+		return function_exists( 'acf_get_value' ) || class_exists( 'ACF' ) || defined( 'ACF_VERSION' );
+	}
+
+	/**
+	 * Show an admin notice when neither ACF nor SCF is active.
+	 *
+	 * @since  1.4
+	 * @access public
+	 */
+	public function maybe_show_dependency_notice() {
+		if ( $this->dependency_active() ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'ACF Hide Layout', 'acf-hide-layout' ); ?>:</strong>
+				<?php esc_html_e( 'This plugin requires Advanced Custom Fields or Secure Custom Fields (SCF) to be installed and active.', 'acf-hide-layout' ); ?>
+			</p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === ACF Hide Layout ===
 Contributors: bleechberlin
-Tags: acf, advanced custom fields, flexible content, hide layout
+Tags: acf, advanced custom fields, secure custom fields, flexible content, hide layout
 Requires at least: 4.7
 Tested up to: 6.9
 Stable tag: 1.3
@@ -16,6 +16,8 @@ Sometimes you may need to hide/remove a flexible content layout from showing on 
 
 Of course you can always just remove the layout, but if it’s a complex group of fields with a lot of data, re-creating it later would be a pain. And here the **ACF Hide Layout** plugin comes into play. It adds a small button with an "eye" icon to easily disable/enable flexible layout content without removing it.
 
+This plugin works with both Advanced Custom Fields and [Secure Custom Fields (SCF)](https://wordpress.org/plugins/secure-custom-fields/), the WordPress.org-maintained fork of ACF. Because SCF ships Flexible Content for free, you can use ACF Hide Layout without ACF Pro.
+
 See more info on the [plugin website](https://flyntwp.com/acf-hide-layout/)
 
 == Frequently Asked Questions ==
@@ -24,6 +26,10 @@ See more info on the [plugin website](https://flyntwp.com/acf-hide-layout/)
 
 Next to the flexible content options "Add Layout" and "Remove Layout" is a new option "Hide / Show Layout".
 Toggling that option will hide or show the layout on the fronted.
+
+= Does it work with Secure Custom Fields (SCF)? =
+
+Yes. SCF is a drop-in fork of ACF and keeps the same API, so ACF Hide Layout works with both. With SCF you also get Flexible Content for free, without ACF Pro.
 
 == Screenshots ==
 
@@ -34,7 +40,7 @@ Toggling that option will hide or show the layout on the fronted.
 == Requirements ==
 
 * [WordPress](https://wordpress.org/) >= 4.7
-* [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) >= 5.7
+* [Advanced Custom Fields Pro](https://www.advancedcustomfields.com/pro/) >= 5.7, or [Secure Custom Fields (SCF)](https://wordpress.org/plugins/secure-custom-fields/)
 
 == Installation ==
 


### PR DESCRIPTION
Closes #13

## What

Make Secure Custom Fields (SCF) a documented, first-class target for ACF Hide Layout.

SCF (the WordPress.org-maintained fork of ACF) is a drop-in replacement that keeps ACF's API, so this plugin already works with it — the gap was only that nothing said so, and there was no graceful fallback when no compatible plugin is active.

## Changes

- **Docs**: declare SCF compatibility in `readme.txt`, `README.md` and the plugin header (description + tags), plus a short FAQ entry. Since SCF ships Flexible Content for free, this plugin can now be used without ACF Pro — worth surfacing.
- **Graceful dependency check**: new `dependency_active()` (detects ACF *or* SCF via `acf_get_value()` / `ACF` class / `ACF_VERSION`) and an `admin_notices` notice shown only when neither is active. No behavior change when ACF or SCF is present.

## Why it already works with SCF (verified against `WordPress/secure-custom-fields` @ 6.8.6)

- All `acf_*` functions this plugin calls exist in SCF (`acf_get_value`, `acf_update_value`, `acf_delete_value`, `acf_get_array`, `acf_decode_post_id`, `acf_get_meta_instance`, `acf_get_metadata_by_field`, `acf_update_metadata_by_field`).
- All hooks are fired by SCF: `acf/load_value/type=flexible_content`, `acf/update_value/type=flexible_content`, `acf/pre_load_metadata`.
- SCF defines `ACF_VERSION` (currently `6.8.6`), so `supports_disabled_layouts()` (≥ 6.5) returns true, and SCF implements the native disabled-layouts feature (`get_disabled_layouts()`, `_layout_meta` with `disabled`/`renamed`) — so the migration path works too.
- JS side: SCF keeps the `window.acf` global, the `ready_field/type=flexible_content` action and the `.acf-fc-layout-controls` markup the admin script hooks into.

## Notes / deliberate non-changes

- **Existing translatable strings left untouched** (e.g. the "ACF 6.5+" wording in the migration notice). Rewording them would invalidate the existing German/Greek/Dutch translations for a purely cosmetic gain, and they remain accurate under SCF (which reports `ACF_VERSION` and inherits the disabled-layouts feature). Only one additive string was introduced.
- **`languages/acf-hide-layout.pot` not regenerated** — I don't want to commit one with stale line references. The new string ("This plugin requires Advanced Custom Fields or Secure Custom Fields (SCF)...") should be picked up by running `wp i18n make-pot` on release.
- Plugin version / `Stable tag` intentionally not bumped — left to you for the next release.

`php -l` passes on the modified plugin file.
